### PR TITLE
Updated getVisibleBounds() to catch lots of weird edge cases

### DIFF
--- a/DrawVisibleBounds.jsx
+++ b/DrawVisibleBounds.jsx
@@ -11,10 +11,11 @@ See the LICENSE file for details.
 
 Versions:
 1.0.0 initial release
+1.0.1 updated getVisibleBounds() to catch lots of weird edge cases
 */
 
 var _title = "Draw Visible Bounds";
-var _version = "1.0.0";
+var _version = "1.0.1";
 var _copyright = "Copyright 2021 Josh Duncan";
 var _website = "joshbduncan.com";
 
@@ -27,7 +28,7 @@ if (app.documents.length > 0) {
         for (var i = 0; i < sel.length; i++) {
             object = sel[i];
             visibleBounds = getVisibleBounds(object);
-            drawBounds(visibleBounds, "VISIBLE");
+            drawBounds(visibleBounds);
         }
     } else {
         alert("No objects are selected!\nSelect at least one object first.");
@@ -84,19 +85,45 @@ function drawBoundMark(pathCoordinates) {
  */
 function getVisibleBounds(object) {
     var bounds, clippedItem;
-    if ((object.typename = "GroupItem" && object.clipped)) {
-        for (var i = 0; i < object.pageItems.length; i++) {
-            if (object.pageItems[i].clipping) {
-                clippedItem = object.pageItems[i];
-                break;
-            } else if (object.pageItems[i].typename == "CompoundPathItem") {
-                if (object.pageItems[i].pathItems[0].clipping) {
+    if (object.typename == "GroupItem") {
+        // if the object is clipped
+        if (object.clipped) {
+            // check all sub objects to find the clipping path
+            for (var i = 0; i < object.pageItems.length; i++) {
+                if (object.pageItems[i].clipping) {
+                    clippedItem = object.pageItems[i];
+                    break;
+                } else if (object.pageItems[i].typename == "CompoundPathItem") {
+                    if (object.pageItems[i].pathItems[0].clipping) {
+                        clippedItem = object.pageItems[i];
+                        break;
+                    }
+                } else {
                     clippedItem = object.pageItems[i];
                     break;
                 }
             }
+            bounds = clippedItem.geometricBounds;
+        } else {
+            // if the object is not clipped
+            var subObjectBounds;
+            var allBoundPoints = [[], [], [], []];
+            // get the bounds of every object in the group
+            for (var i = 0; i < object.pageItems.length; i++) {
+                subObjectBounds = getVisibleBounds(object.pageItems[i]);
+                allBoundPoints[0].push(subObjectBounds[0]);
+                allBoundPoints[1].push(subObjectBounds[1]);
+                allBoundPoints[2].push(subObjectBounds[2]);
+                allBoundPoints[3].push(subObjectBounds[3]);
+            }
+            // determine the groups bounds from it sub object bound points
+            bounds = [
+                Math.min.apply(Math, allBoundPoints[0]),
+                Math.max.apply(Math, allBoundPoints[1]),
+                Math.max.apply(Math, allBoundPoints[2]),
+                Math.min.apply(Math, allBoundPoints[3]),
+            ];
         }
-        bounds = clippedItem.geometricBounds;
     } else {
         bounds = object.geometricBounds;
     }


### PR DESCRIPTION
This update to the getVisibleBounds() function is in response to some edge cases that were causing runtime errors. I'm sure there are a ton of edge cases this update will not catch (especially with exported artwork from other software) but it seems to fix quite a few of the most common I have encountered.

Now, if the function encounters a `GroupItem` that **IS NOT** `clipped` it will recursively go through each of the group's children objects, storing their bounds (left, top, right, bottom) in the `allBoundPoints` array. Then the function can determine the overall visual bounds of the group by taking the min value of the left bound points, the max value of the top bound points, the max value of the right bound points, and the min value of the bottom bound points.

Edge Cases Tested:
- non-clipped GroupItem
- clipping path made up of grouped objects (Clip Group)
- clipping path made up of a single grouped object
- nested clipped objects
- groups made up of assorted object types
- clipped objects in empty groups
- clipped text

For testing purposes, I created the script _DrawVisualBounds.jsx_. If you have artwork or edge cases you would like to test, feel free to download and run this script against them. It works on all of the selected objects in your current Illustrator document and simply draws right angle tick marks at the visual bounds determined by the function. 

This function is currently only used in the _MatchObjects.jsx_ script to help determine the positioning and size of objects.